### PR TITLE
chore: ignore public supabase secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ apps/*/node_modules/*
 /build
 /.next/
 /out/
+apps/*/.next/
+apps/*/.netlify/
 
 # Logs
 logs

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,9 @@
   command = "npm run migrate && turbo build --filter=web"
   publish = "apps/web/.next"
 
+[build.environment]
+  SECRETS_SCAN_OMIT_KEYS = "NEXT_PUBLIC_SUPABASE_ANON_KEY,NEXT_PUBLIC_SUPABASE_URL"
+
 # Staging context (staging branch)
 [context.staging]
   command = "npm run migrate && turbo build --filter=web"


### PR DESCRIPTION
## Summary
- configure Netlify to ignore public Supabase env vars during secret scanning
- ignore build artifacts for app packages

## Testing
- `npm test` *(fails: Snapshot mismatched / jest is not defined)*
- `npm run lint` *(fails: Cannot find module '@humanwhocodes/config-array')*


------
https://chatgpt.com/codex/tasks/task_e_68c093cb6268832ca335f435443a7d3f