### PR TITLE
docs: refine epic 2 story drafts

### DIFF
--- a/docs/stories/2.1.guia-boas-praticas.md
+++ b/docs/stories/2.1.guia-boas-praticas.md
@@ -1,0 +1,37 @@
+# História 2.1: Guia de Boas Práticas
+
+## Status
+Draft
+
+## Story
+**Como** um vendedor,
+**eu quero** ver dicas claras sobre como tirar uma boa foto de referência,
+**para que** eu possa fornecer a melhor imagem possível para a IA.
+
+## Context Source
+- Source Document: docs/prd/03-epic-2.md
+- Enhancement Type: feature
+- Existing System Impact: interface de upload de fotos
+
+## Critérios de Aceitação
+1. Durante o processo de upload, a interface exibe uma lista de dicas (ex: "✅ Use boa iluminação", "✅ Mantenha a foto nítida").
+2. A funcionalidade atual de upload de fotos continua funcionando sem alterações.
+3. A integração com o processamento de imagens existente permanece inalterada.
+4. O fluxo de envio de fotos não apresenta regressões.
+5. O desempenho do upload mantém-se dentro dos limites aceitáveis.
+
+## Tasks / Subtasks
+- [ ] Definir e exibir a lista de dicas durante o upload.
+- [ ] Ajustar o layout da interface para acomodar as dicas.
+- [ ] Criar testes de interface garantindo a exibição das dicas.
+
+## Dev Notes
+### Testing
+- Use o padrão de testes de interface existente em `front-end-spec.md`.
+- Crie testes automatizados cobrindo a renderização das dicas.
+- Execute `npm test` para validar.
+
+## Change Log
+| Date | Version | Description | Author |
+| --- | --- | --- | --- |
+| 2025-09-07 | 1.0 | Initial draft | ChatGPT |

--- a/docs/stories/2.2.planejamento-pacote-imagens.md
+++ b/docs/stories/2.2.planejamento-pacote-imagens.md
@@ -1,0 +1,37 @@
+# História 2.2: Planejamento do Pacote de Imagens por IA
+
+## Status
+Draft
+
+## Story
+**Como** um vendedor,
+**eu quero** que a IA analise meu produto e proponha um plano de geração de imagens otimizado,
+**para que** eu receba um conjunto de fotos eficaz para a minha categoria.
+
+## Context Source
+- Source Document: docs/prd/03-epic-2.md
+- Enhancement Type: feature
+- Existing System Impact: fluxo de geração de imagens
+
+## Critérios de Aceitação
+1. Com base nas informações do produto, um modelo de IA com capacidade de raciocínio deve criar um "plano de geração".
+2. O plano deve definir os tipos de imagem a serem criados (ex: "Foto principal", "Foto de estilo de vida", "Foto de detalhe").
+3. A IA de geração de imagem executa este plano para criar o pacote de fotos.
+4. O fluxo manual de geração de imagens continua funcionando sem alterações.
+5. A integração com o processo de upload e pacotes existentes mantém-se inalterada.
+
+## Tasks / Subtasks
+- [ ] Implementar modelo de IA para planejar o pacote de imagens.
+- [ ] Integrar o plano com o gerador de imagens existente.
+- [ ] Validar o plano gerado em testes automatizados.
+
+## Dev Notes
+### Testing
+- Utilize padrões de teste de geração de imagens descritos em `front-end-spec.md`.
+- Crie testes de integração verificando a execução do plano.
+- Execute `npm test` para validar.
+
+## Change Log
+| Date | Version | Description | Author |
+| --- | --- | --- | --- |
+| 2025-09-07 | 1.0 | Initial draft | ChatGPT |

--- a/docs/stories/2.3.refinamento-interativo-texto.md
+++ b/docs/stories/2.3.refinamento-interativo-texto.md
@@ -1,0 +1,37 @@
+# História 2.3: Refinamento Interativo via Texto
+
+## Status
+Draft
+
+## Story
+**Como** um vendedor,
+**eu quero** poder digitar pedidos de alteração em linguagem natural e receber novas versões,
+**para que** eu possa ajustar o resultado final.
+
+## Context Source
+- Source Document: docs/prd/03-epic-2.md
+- Enhancement Type: feature
+- Existing System Impact: tela de resultados e consumo de créditos
+
+## Critérios de Aceitação
+1. Na tela de resultados, cada imagem deve ter um campo de texto para "Solicitar Alterações", além de botões de sugestões.
+2. O sistema de IA deve gerenciar o contexto da conversa para entender pedidos sequenciais.
+3. O usuário tem um número limitado de refinamentos gratuitos por pacote.
+4. A exibição e download das imagens existentes permanecem inalterados.
+5. O gerenciamento de sessão não apresenta regressões.
+
+## Tasks / Subtasks
+- [ ] Criar interface para refinamento de imagens via texto.
+- [ ] Gerenciar histórico de conversa e limites de refinamento.
+- [ ] Adicionar testes garantindo preservação do contexto da conversa.
+
+## Dev Notes
+### Testing
+- Utilize testes de integração para o fluxo de refinamento.
+- Verifique limites de refinamento por pacote.
+- Execute `npm test` para validar.
+
+## Change Log
+| Date | Version | Description | Author |
+| --- | --- | --- | --- |
+| 2025-09-07 | 1.0 | Initial draft | ChatGPT |

--- a/docs/stories/2.4.validacao-feedback.md
+++ b/docs/stories/2.4.validacao-feedback.md
@@ -1,0 +1,37 @@
+# História 2.4: Validação e Feedback do Usuário
+
+## Status
+Draft
+
+## Story
+**Como** um vendedor,
+**eu quero** uma forma fácil de avaliar e descartar imagens geradas que não ficaram boas,
+**para que** eu tenha controle sobre a qualidade final.
+
+## Context Source
+- Source Document: docs/prd/03-epic-2.md
+- Enhancement Type: feature
+- Existing System Impact: gerenciamento de imagens e créditos
+
+## Critérios de Aceitação
+1. Cada imagem gerada terá opções de avaliação (👍 e 👎).
+2. Se o usuário clicar em 👎, uma lista de motivos predefinidos aparecerá (ex: "O produto está distorcido", "Parece falso").
+3. Selecionar um motivo remove a imagem e não consome os créditos de refinamento.
+4. O feedback deve ser armazenado para análise.
+5. O gerenciamento atual de imagens e créditos permanece funcionando sem regressões.
+
+## Tasks / Subtasks
+- [ ] Adicionar UI de avaliação e descarte de imagens.
+- [ ] Persistir feedback do usuário para análise.
+- [ ] Cobrir o fluxo de avaliação com testes automatizados.
+
+## Dev Notes
+### Testing
+- Aplique padrões de teste de avaliação de imagens existentes.
+- Valide armazenamento e remoção de imagens via testes.
+- Execute `npm test` para validar.
+
+## Change Log
+| Date | Version | Description | Author |
+| --- | --- | --- | --- |
+| 2025-09-07 | 1.0 | Initial draft | ChatGPT |


### PR DESCRIPTION
## Summary
- localize story titles to Portuguese and expand acceptance criteria
- add tasks and testing guidance for each Epic 2 story

## Testing
- `npm test` *(fails: 21 snapshots failed, 8 test files failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1724121e4832ca523d81eeae2e016